### PR TITLE
Add bottom navigation bar with todos and profile screens

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:todo_app/models/user.dart';
+import 'package:todo_app/screens/profile.dart';
+import 'package:todo_app/screens/todo.dart';
+
+class HomeScreen extends ConsumerStatefulWidget {
+  final AppUser user;
+  const HomeScreen({super.key, required this.user});
+
+  @override
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: [
+          TodoScreen(user: widget.user),
+          ProfileScreen(user: widget.user),
+        ],
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: (int index) {
+          setState(() {
+            _selectedIndex = index;
+          });
+        },
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.list_alt),
+            label: 'Todos',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.person),
+            label: 'Profile',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:todo_app/models/user.dart';
+import 'package:todo_app/providers/theme_switch.dart';
+import 'package:todo_app/widgets/signout_dialog.dart';
+
+class ProfileScreen extends ConsumerWidget {
+  final AppUser user;
+
+  const ProfileScreen({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isLightTheme = ref.watch(themeSwitchProvider) == Brightness.light;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("${user.name}'s Profile"),
+        actions: [
+          IconButton(
+              icon: Icon((isLightTheme) ? Icons.dark_mode : Icons.light_mode),
+              tooltip: 'Dark theme',
+              onPressed: () {
+                ref.read(themeSwitchProvider.notifier).update(
+                    (isLightTheme) ? Brightness.dark : Brightness.light);
+              }),
+          IconButton(
+              icon: const Icon(Icons.logout),
+              tooltip: 'Log out',
+              onPressed: () {
+                showDialog(
+                    context: context,
+                    builder: (ctx) => SignOutDialog(parentContext: context));
+              }),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircleAvatar(
+              radius: 50,
+              backgroundImage: NetworkImage(user.profilePicUrl),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'Completed Todos: ${user.completedTodosCount}',
+              style: const TextStyle(fontSize: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/todo.dart
+++ b/lib/screens/todo.dart
@@ -51,23 +51,6 @@ class _TodoScreenState extends ConsumerState<TodoScreen> {
       appBar: AppBar(
         titleSpacing: 12.w,
         title: Text("${widget.user.name}'s todos"),
-        actions: [
-          IconButton(
-              icon: Icon((isLightTheme) ? Icons.dark_mode : Icons.light_mode),
-              tooltip: 'Dark theme',
-              onPressed: () {
-                ref.read(themeSwitchProvider.notifier).update(
-                    (isLightTheme) ? Brightness.dark : Brightness.light);
-              }),
-          IconButton(
-              icon: const Icon(Icons.logout),
-              tooltip: 'Log out',
-              onPressed: () {
-                showDialog(
-                    context: context,
-                    builder: (ctx) => SignOutDialog(parentContext: context));
-              }),
-        ],
       ),
       body: SafeArea(
           child: Column(

--- a/lib/widgets/start_app.dart
+++ b/lib/widgets/start_app.dart
@@ -5,7 +5,7 @@ import 'package:todo_app/providers/firebase.dart';
 import 'package:todo_app/providers/logged_user.dart';
 import 'package:todo_app/screens/onboarding.dart';
 import 'package:todo_app/screens/splash.dart';
-import 'package:todo_app/screens/todo.dart';
+import 'package:todo_app/screens/home.dart';
 
 class StartApp extends ConsumerWidget {
   final Widget _loadingScreen =
@@ -33,7 +33,7 @@ class StartApp extends ConsumerWidget {
         return const OnboardingScreen();
       }
     } else {
-      return TodoScreen(user: user);
+      return HomeScreen(user: user);
     }
   }
 }


### PR DESCRIPTION
This PR adds a bottom navigation bar to the home screen with two tabs:

- Todos list with calendar
- Profile screen with profile picture and completed todos count

Changes:
- Created new HomeScreen widget to manage bottom navigation
- Moved theme and logout buttons from TodoScreen to ProfileScreen
- Updated StartApp widget to use the new HomeScreen
- Added profile screen with user stats