### PR TITLE
Fix intl version conflict

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -561,10 +561,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: 3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     easy_date_timeline: ^2.0.9
     gap: ^3.0.1
     animated_list_plus: ^0.5.2
-    intl: ^0.19.0
+    intl: ^0.20.2
     entry: ^1.0.0
     flutter_riverpod: 2.6.1
     riverpod_annotation: 2.6.1


### PR DESCRIPTION
## Summary
- bump `intl` dependency to 0.20.2
- update lockfile

## Testing
- `apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_6862a8ca2bb88329a9a47976171f4d02